### PR TITLE
Set network to be host while running operator in docker containers

### DIFF
--- a/customer_support_operator.sh
+++ b/customer_support_operator.sh
@@ -15,4 +15,4 @@ LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 # build
 $LOCAL_DIRECTORY/scripts/build.sh
 
-docker run -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-customer-support.sh llm_operator:latest "$@"
+docker run --network="host" -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-customer-support.sh llm_operator:latest "$@"

--- a/food_delivery_operator.sh
+++ b/food_delivery_operator.sh
@@ -15,4 +15,4 @@ LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 # build
 $LOCAL_DIRECTORY/scripts/build.sh
 
-docker run -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-food-delivery.sh llm_operator:latest "$@"
+docker run --network="host" -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-food-delivery.sh llm_operator:latest "$@"

--- a/motivation_operator.sh
+++ b/motivation_operator.sh
@@ -15,4 +15,4 @@ LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 # build
 $LOCAL_DIRECTORY/scripts/build.sh
 
-docker run -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-motivation.sh llm_operator:latest "$@"
+docker run --network="host" -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-motivation.sh llm_operator:latest "$@"

--- a/onboarding_operator.sh
+++ b/onboarding_operator.sh
@@ -15,4 +15,4 @@ LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 # build
 $LOCAL_DIRECTORY/scripts/build.sh
 
-docker run -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-onboarding.sh llm_operator:latest "$@"
+docker run --network="host" -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-onboarding.sh llm_operator:latest "$@"

--- a/operator_of_operators.sh
+++ b/operator_of_operators.sh
@@ -15,4 +15,4 @@ LOCAL_DIRECTORY="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd
 # build
 $LOCAL_DIRECTORY/scripts/build.sh
 
-docker run -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-operator-of-operators.sh llm_operator:latest "$@"
+docker run --network="host" -v ~/.powerml:/root/.powerml -v $LOCAL_DIRECTORY/data:/app/llm_operator/data -v $LOCAL_DIRECTORY/models:/app/llm_operator/models -it --rm --entrypoint /app/llm_operator/scripts/start-operator-of-operators.sh llm_operator:latest "$@"


### PR DESCRIPTION
To facilitate local testing of the lamini platform, we want to reset the localhost to be the host.

Testing Steps:
1. Run the powerml configure to be localhost
```
(base) ubuntu@ip-10-217-30-221:~/lamini/llm-operator$ cat ~/.powerml/configure_llama.yaml
production:
    key: "test_token"
    url: "http://localhost:5001"
```
2. Test with `./food_delivery_operator.sh` to verify